### PR TITLE
Added on screen error if user tries to signup with already used email.

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -5,18 +5,14 @@
         <img src="assets/logo/fitness_tracker_logo2.png" alt="logo">
       </div>
 
-      <!-- this will show the form values on the login screen as they are typed in to check input  -->
-      login form values: {{loginForm.value | json }}
-
-      <hr>
+      <!-- this will show the form values on the 
+      login screen as they are typed in to check input -->
+      <!-- login form values: {{loginForm.value | json }}
+      <hr> -->
       
       <h1 class='text-center font-weight-bold'>
         Log in to your account
       </h1>
-
-      <!-- <p class="text-sm-left">
-        Create your own free account to track your fitness and challenge your friends!!
-      </p> -->
 
       <label for="inputEmail" class="sr-only">
         Email 
@@ -42,7 +38,7 @@
         </label>
       </div>
 
-      <button [disabled]='loginForm.invalid' *ngIf='!submitted' id='sign-in-btn' class="btn btn-lg btn-primary btn-block border: 1px solid aqua;
+      <button [disabled]='email.invalid || password.invalid' *ngIf='!submitted' id='sign-in-btn' class="btn btn-lg btn-primary btn-block border: 1px solid aqua;
       border-color: #00fff0;" type="submit">
         Log In 
       </button>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -59,7 +59,7 @@ export class LoginComponent implements OnInit {
         Validators.required,
         Validators.minLength(6)
       ]],
-      rememberUser: [false, [
+      rememberUser: [true, [
         Validators.requiredTrue
       ]]
     });

--- a/src/app/registration/registration.component.html
+++ b/src/app/registration/registration.component.html
@@ -4,10 +4,6 @@
     <div class='img-circle text-center'>
       <img src="assets/logo/fitness_tracker_logo2.png" alt="logo">
     </div>
-
-    <!-- {{userForm.value | json}}
-    <hr>
-    {{user | json}} -->
     
     <h1 class='text-md-left'>
       Challenge yourself.
@@ -23,7 +19,11 @@
     </label>
     <input formControlName='email' id="inputEmail" class="form-control"  placeholder="Email" required autofocus>
     <mat-error *ngIf="email.invalid && email.touched">
-      Email must have an @ sign
+      Email must have an @ sign! <br>
+    </mat-error>
+    <mat-error *ngIf='error && email.valid'>
+      Already signed up with that e-mail! <br>
+      Please login or sign up with a different one!!
     </mat-error>
 
     <label for="inputPassword" class="sr-only">
@@ -34,6 +34,7 @@
       Password must be six characters
     </mat-error>
 
+
     <div class="checkbox mb-3">
       <label>
         <input formControlName='shouldLogIn' type="checkbox" value="remember-me"> 
@@ -41,16 +42,12 @@
       </label>
     </div>
 
-    <!-- <div>
-      <br>
-    </div> -->
-
-    <button [disabled]='registrationForm.invalid' *ngIf='!submitted' id='sign-in-btn' class="btn btn-lg btn-primary btn-block border: 1px solid aqua;
+    <button [disabled]='email.invalid || password.invalid' *ngIf='!submitted' id='sign-in-btn' class="btn btn-lg btn-primary btn-block border: 1px solid aqua;
     border-color: #00fff0;" type="submit">
       Sign up
     </button>
 
-    <button [disabled]='registrationForm.invalid' *ngIf='!submitted' class="btn btn-lg btn-primary btn-block" id='google-btn'>
+    <button [disabled]='email.invalid || password.invalid' *ngIf='!submitted' class="btn btn-lg btn-primary btn-block" id='google-btn'>
         <img src="https://img.icons8.com/small/16/000000/google-logo.png">
         <span> Sign up with Google! </span> 
       </button>

--- a/src/app/registration/registration.component.ts
+++ b/src/app/registration/registration.component.ts
@@ -29,6 +29,7 @@ export class RegistrationComponent implements OnInit {
   user: User = new User;
   shouldLogIn: boolean = false;
   submitted: boolean = false;
+  error: boolean = false;
 
   ngOnInit() {
     this.authService.loadRememberedUser();
@@ -41,7 +42,7 @@ export class RegistrationComponent implements OnInit {
         Validators.required,
         Validators.minLength(6)
       ]],
-      shouldLogIn: [false, [
+      shouldLogIn: [true, [
         Validators.requiredTrue
       ]]
     });
@@ -71,13 +72,18 @@ export class RegistrationComponent implements OnInit {
     .subscribe(
       data => {
         console.log('Signup success', data.user._id);
+        // this.error = false;
         if(this.shouldLogIn)
           this.authService.login(this.user); 
         this.router.navigate(['/login']);
       }, 
 
       //TODO: show errors on screen instead of console
-      error => console.log('Error on signup!', error)
+      error => { 
+        console.log('Error on signup!', error)
+        this.error = true;
+        this.submitted = false;
+      }
     );
   };
 


### PR DESCRIPTION
Signup and login buttons no longer disabled by the 'log me in' and 'remember me' check-boxes in the signup and login pages. Now only disabled when the email or password are invalid.

Remember me and log me in check-boxes are checked now by default when visiting login or signup routes.